### PR TITLE
JsonResponse

### DIFF
--- a/src/Controller/HelloController.php
+++ b/src/Controller/HelloController.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 class HelloController extends AbstractController
@@ -15,15 +16,15 @@ class HelloController extends AbstractController
      */
     public function index(Request $request)
     {
-        // $name = $request->get('name');
-        // $pass = $request->get('pass');
-        $result = '<html><body>';
-        $result .= '<h1>クエリパラメーターを表示</h1>';
-        // $result .= '<p>name: ' . $name . '</p>';
-        // $result .= '<p>pass: ' . $pass . '</p>';
-        $result .= '</body></html>';
-
-        return new Response($result);
+        $data = array(
+            'name' => array(
+                'first' => 'Taro',
+                'second' => 'Yamada'
+            ),
+            'age' => 36,
+            'mail' => 'taro@yamada.kun'
+        );
+        return new JsonResponse($data);
     }
 
     /**


### PR DESCRIPTION
- 配列でデータを用意

`new JsonResponse(配列)`

- Json形式のテキストを用意

`JsonResponse::fromJsonString(テキスト`


![スクリーンショット 2023-10-14 7 45 31](https://github.com/ta9son/SymfonyBasics/assets/47817205/f9902b3d-7e35-4dd3-9755-902fab73c5a5)
